### PR TITLE
accepting POST to retry resque jobs

### DIFF
--- a/lib/restash/conf.rb
+++ b/lib/restash/conf.rb
@@ -20,3 +20,5 @@ module Restash
 
   end
 end
+
+require 'restash/resque_server'

--- a/lib/restash/resque_server.rb
+++ b/lib/restash/resque_server.rb
@@ -1,0 +1,25 @@
+require 'resque/server'
+require 'json'
+
+module Restash
+  module ResqueServer
+    def self.included(base)
+      base.class_eval do
+
+        get "/restash/ping" do
+          { status: :ok }.to_json
+        end
+
+        post "/restash/retry" do
+          p = JSON.parse(request.body.read)
+          success = Resque.enqueue_to(p['queue'], p['payload']['class'].constantize, *p['payload']['args'])
+          { success: success }.to_json
+        end
+      end
+    end
+  end
+end
+
+Resque::Server.class_eval do
+  include Restash::ResqueServer
+end

--- a/lib/restash/version.rb
+++ b/lib/restash/version.rb
@@ -1,3 +1,3 @@
 module Restash
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
 end

--- a/restash.gemspec
+++ b/restash.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_runtime_dependency 'logstash-logger'
+  spec.add_runtime_dependency 'resque'
+  spec.add_runtime_dependency 'json'
 end


### PR DESCRIPTION
tested it locally with postman. json in POST taken from kibana, for example:

POST http://api.yotpo.com/resque/restash/retry
{"payload":{"class":"SummaryReportTasks::ChargifyTask","args":[{"method":"process_and_save_bulk","current_bulk":[1]}]}}

only thing that's missing now is a chrome extension for kibana that reads this json from the DOM, and we're done.

@vladshub @burdandrei 

https://github.com/YotpoLtd/yotpo-api/pull/1692
