### PR TITLE
moving to tcp. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ Resque::Failure::Multiple.classes = [Resque::Failure::Redis, Resque::Failure::Lo
 Resque::Failure.backend = Resque::Failure::Multiple
 ```
 
-Configure logstash host and port (currently support only udp)
+Configure logstash host and port. Supports only tcp, due to the large payload. A timeout can be passed in the options.
 ```
 Restash::Conf.configure do |conf|
   conf.logstash_host = ENV['LOGSTASH_HOST']
   conf.logstash_port = ENV['LOGSTASH_PORT']
+  conf.options = {connect_timeout: timeout1, write_timeout: timeout2, read_timeout: timeout3}
 end
 ```
+
+Additional options can be explored in the [TCPTimeout](https://github.com/lann/tcp-timeout-ruby) project. The options are passed as is to a new TCPTimeout::TCPSocket object on every message.
 
 
 ## License

--- a/lib/resque/failure/logstash.rb
+++ b/lib/resque/failure/logstash.rb
@@ -7,11 +7,12 @@ module Resque
 
       def save
         begin
-          Restash::Conf.logger.fatal exception: exception.to_s,
-                                     failure_line: exception.backtrace[0],
-                                     worker: worker.to_s,
-                                     queue: queue,
-                                     payload: payload
+          Restash::Conf.logger.write({ exception: exception.to_s,
+                                       backtrace: exception.backtrace,
+                                       worker: worker.to_s,
+                                       queue: queue,
+                                       payload: payload,
+                                       tags: [:resque_failure] }.to_json)
         rescue => e
           puts "Failed to send to logstash: #{e.message}\n#{e.backtrace}"
         end

--- a/lib/restash/conf.rb
+++ b/lib/restash/conf.rb
@@ -1,11 +1,11 @@
-require 'logstash-logger'
+require 'restash/logger'
 
 module Restash
   class Conf
 
     class << self
 
-      attr_accessor :logstash_host, :logstash_port
+      attr_accessor :logstash_host, :logstash_port, :options
 
       def configure
         yield self
@@ -13,7 +13,7 @@ module Restash
       end
 
       def logger
-        @logger ||= LogStashLogger.new(logstash_host, logstash_port)
+        @logger ||= Restash::Logger.new(logstash_host, logstash_port, options)
       end
 
     end

--- a/lib/restash/logger.rb
+++ b/lib/restash/logger.rb
@@ -1,0 +1,20 @@
+require 'tcp_timeout'
+
+module Restash
+  class Logger
+
+    def initialize(host, port, options)
+      @host = host
+      @port = port
+      @options = options
+    end
+
+    def write(data)
+      sock = TCPTimeout::TCPSocket.new(@host, @port, @options)
+      sock.write(data)
+      sock.close
+    end
+
+  end
+end
+

--- a/lib/restash/version.rb
+++ b/lib/restash/version.rb
@@ -1,3 +1,3 @@
 module Restash
-  VERSION = '0.2.1'
+  VERSION = '0.3.1'
 end

--- a/restash.gemspec
+++ b/restash.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_runtime_dependency 'logstash-logger'
   spec.add_runtime_dependency 'resque'
   spec.add_runtime_dependency 'json'
+  spec.add_runtime_dependency 'tcp_timeout'
 end


### PR DESCRIPTION
if the connection fails, nothing happens (checked). so it shouldn't be a problem. supports passing timeout so that the tcp connection doesn't hang the process.
